### PR TITLE
Add Universal Agentic Registry API (HOL)

### DIFF
--- a/apis.json
+++ b/apis.json
@@ -129,5 +129,18 @@
     "https": true,
     "cors": true,
     "rateLimit": "Varies by service"
+  },
+  {
+    "id": "hol_registry_broker",
+    "name": "Universal Agentic Registry API (HOL)",
+    "description": "Universal discovery layer for AI agents and MCP servers.",
+    "category": "Development",
+    "url": "https://hol.org/registry/api/v1",
+    "pricing": "free",
+    "documentation": "https://hol.org/docs/registry-broker/",
+    "auth": true,
+    "https": true,
+    "cors": true,
+    "rateLimit": "Free tier available"
   }
 ]


### PR DESCRIPTION
Adds Hashgraph Online (HOL) Universal Agentic Registry API / Registry Broker to apis.json.\n\nDocs: https://hol.org/docs/registry-broker/\nOpenAPI: https://hol.org/registry/api/v1/openapi.json\nBase: https://hol.org/registry/api/v1\nAPIs.json: https://hol.org/registry/apis.json